### PR TITLE
Upgrade Event Recorder

### DIFF
--- a/pkg/controller/reconcile/watch.go
+++ b/pkg/controller/reconcile/watch.go
@@ -44,14 +44,14 @@ func Watch(
 	}
 
 	// watch the resource if it current is not being watched
-	eventHandler := handler.EnqueueRequestForOwner(
-		r.GetManager().GetScheme(),
-		r.GetManager().GetRESTMapper(),
-		req.Workload,
-		handler.OnlyControllerOwner(),
-	)
-
 	if !watched {
+		eventHandler := handler.EnqueueRequestForOwner(
+			r.GetManager().GetScheme(),
+			r.GetManager().GetRESTMapper(),
+			req.Workload,
+			handler.OnlyControllerOwner(),
+		)
+
 		syncingSource := source.Kind(
 			r.GetManager().GetCache(),
 			resource,

--- a/pkg/controller/workload/reconciler.go
+++ b/pkg/controller/workload/reconciler.go
@@ -4,7 +4,7 @@ package workload
 
 import (
 	"github.com/go-logr/logr"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -20,7 +20,7 @@ type Reconciler interface {
 	GetManager() manager.Manager
 	GetLogger() logr.Logger
 	GetResources(*Request) ([]client.Object, error)
-	GetEventRecorder() record.EventRecorder
+	GetEventRecorder() events.EventRecorder
 	GetFieldManager() string
 	GetWatches() []client.Object
 	SetWatch(client.Object)

--- a/pkg/status/events.go
+++ b/pkg/status/events.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -48,17 +48,17 @@ func (event Event) Type() string {
 // cluster-scoped resources, you will see the events when describing the object and nowhere else.  For
 // namespace-scoped resources, you can also see the events by getting events in the particular
 // namespace.
-func (event Event) RegisterAction(recorder record.EventRecorder, child, parent client.Object) {
-	recorder.Event(
+func (event Event) RegisterAction(recorder events.EventRecorder, child, parent client.Object) {
+	recorder.Eventf(
 		parent,
+		child,
 		event.Type(),
 		event.String(),
-		fmt.Sprintf(
-			"%s child resource '%s' managed by parent resource '%s'",
-			event.String(),
-			getMessageString(child),
-			getMessageString(parent),
-		),
+		event.String(),
+		"%s child resource '%s' managed by parent resource '%s'",
+		event.String(),
+		getMessageString(child),
+		getMessageString(parent),
 	)
 }
 


### PR DESCRIPTION
This simply upgrades the event recorder from a record.EventRecorder to an events.EventRecorder.  The purpose behind this is to remove the deprecated record.EventRecorder so that we are compatible with future versions of controller-runtime.